### PR TITLE
fix sorting, cycle detection still broken

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -297,7 +297,7 @@ async fn run_build_from_args(args: BuildOpts, multi_progress: MultiProgress) -> 
                 .map_err(|err| ParsingError::from_partial(&recipe_text, err))?;
 
             if args.render_only {
-                tracing::info!("{}", serde_yaml::to_string(&recipe).unwrap());
+                // tracing::info!("{}", serde_yaml::to_string(&recipe).unwrap());
                 tracing::info!("Variant: {:#?}", variant);
                 tracing::info!("Hash: {}", recipe.build().string().unwrap());
                 tracing::info!("Skip?: {}\n", recipe.build().skip());
@@ -371,13 +371,15 @@ async fn run_build_from_args(args: BuildOpts, multi_progress: MultiProgress) -> 
     }
 
     // Topological sort of the outputs
-    let outputs = rattler_build::metadata::topological_sort(outputs);
+    let outputs = rattler_build::metadata::topological_sort(outputs).into_diagnostic()?;
 
     // Now build in the
     for output in outputs {
         if !args.render_only {
             tracing::info!("Building package: {}", output.identifier());
             run_build(&output, tool_config.clone()).await?;
+        } else {
+            tracing::info!("Rendering recipe: {}", output.identifier());
         }
     }
 


### PR DESCRIPTION
I did some work on the topological sort. I made the `find_roots` function (which should better be called `find_leafs`) behave properly and changed how we find dependencies. This works OK.

I think we should move the sorting though into an earlier stage (basically before applying variants) and then use that sorting throughout the building process.
E.g. it might be better to find the general sort without taking into account multiple outputs etc. as `libzlib -> zlib_wapi -> zlib` and then we just expand variants afterwards and sort based on that initial sorting.